### PR TITLE
Fix grammar error on unit tests

### DIFF
--- a/UnitTest/classes/ConfigTest.php
+++ b/UnitTest/classes/ConfigTest.php
@@ -28,32 +28,32 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     public function testGet_ExtensibilityAndMultipleLevels() {
         \MPF\ENV::setType('production');
         $test1 = Config::get('configTest')->test1;
-        $this->assertTrue(('prod' == $test1), 'The value should of been "prod" and not "'.print_r($test1, true).'"');
+        $this->assertTrue(('prod' == $test1), 'The value should have been "prod" and not "'.print_r($test1, true).'"');
 
         \MPF\ENV::setType('development');
         $test1 = Config::get('configTest')->test1;
-        $this->assertTrue(('dev' == $test1), 'The value should of been "dev" and not "'.print_r($test1, true).'"');
+        $this->assertTrue(('dev' == $test1), 'The value should have been "dev" and not "'.print_r($test1, true).'"');
 
         \MPF\ENV::setType('development');
         $test2 = Config::get('configTest')->test2;
-        $this->assertTrue(('prod' == $test2), 'The value should of been "prod" and not "'.print_r($test2, true).'"');
+        $this->assertTrue(('prod' == $test2), 'The value should have been "prod" and not "'.print_r($test2, true).'"');
 
         $bool = Config::get('configTest')->bool;
-        $this->assertTrue(is_bool($bool), 'The value should of been a boolean');
+        $this->assertTrue(is_bool($bool), 'The value should have been a boolean');
 
         $integer = Config::get('configTest')->integer;
-        $this->assertTrue(is_int($integer), 'The value should of been a integer');
+        $this->assertTrue(is_int($integer), 'The value should have been a integer');
 
         $float = Config::get('configTest')->float;
-        $this->assertTrue(is_float($float), 'The value should of been a float');
+        $this->assertTrue(is_float($float), 'The value should have been a float');
 
         $string = Config::get('configTest')->string;
-        $this->assertTrue(is_string($string), 'The value should of been a string');
+        $this->assertTrue(is_string($string), 'The value should have been a string');
 
         $level2 = Config::get('configTest')->level1->level2;
-        $this->assertTrue(('level2' == $level2), 'The value should of been "level2" and not "'.print_r($level2, true).'"');
+        $this->assertTrue(('level2' == $level2), 'The value should have been "level2" and not "'.print_r($level2, true).'"');
 
         $level3 = Config::get('configTest')->level1->level3->level33;
-        $this->assertTrue(('level3' == $level3), 'The value should of been "level3" and not "'.print_r($level3, true).'"');
+        $this->assertTrue(('level3' == $level3), 'The value should have been "level3" and not "'.print_r($level3, true).'"');
     }
 }

--- a/UnitTest/classes/Db/ModelTest.php
+++ b/UnitTest/classes/Db/ModelTest.php
@@ -87,7 +87,7 @@ class ModelTest extends PHPUnit_Framework_TestCase
         $model = new ModelExample();
         $model->setField('testLength', "test");
         $json = $model->toJson();
-        $this->assertEquals('{"id":null,"integerTest":null,"creationDate":null,"mydate":"2000-01-01","mydatetime":"2000-01-01 00:00:00","lastAttempt":null,"username":"false","testLength":"test","color":"test","statuses":[]}', $json, "The function toJson should of returned the proper string for the test");
+        $this->assertEquals('{"id":null,"integerTest":null,"creationDate":null,"mydate":"2000-01-01","mydatetime":"2000-01-01 00:00:00","lastAttempt":null,"username":"false","testLength":"test","color":"test","statuses":[]}', $json, "The function toJson should have returned the proper string for the test");
     }
 
     public function testFromJson()
@@ -97,7 +97,7 @@ class ModelTest extends PHPUnit_Framework_TestCase
         $json = $model->toJson();
         $model = ModelExample::fromJson($json);
         $newJson = $model->toJson();
-        $this->assertEquals($newJson, $json, "The function fromJson should of returned the proper string for the test");
+        $this->assertEquals($newJson, $json, "The function fromJson should have returned the proper string for the test");
     }
 
     public function testGetSaltType() {

--- a/UnitTest/classes/TextTest.php
+++ b/UnitTest/classes/TextTest.php
@@ -31,41 +31,41 @@ class TextTest extends PHPUnit_Framework_TestCase
     public function testReplaceMarker()
     {
         $text = Text::byXml('test')->get('testReplace', array('Replace'=>array('name' => 'bob')));
-        $this->assertEquals('test the bob plz!', $text, 'The marker @name@ should of been replaced by "bob" and wasnt.');
+        $this->assertEquals('test the bob plz!', $text, 'The marker @name@ should have been replaced by "bob" and wasnt.');
     }
 
     public function testGetId_validId()
     {
         $text = Text::byXml('test');
-        $this->assertEquals('test value 2', $text->get('test2'), 'The value of the id "test2" should of been "test value 2".');
+        $this->assertEquals('test value 2', $text->get('test2'), 'The value of the id "test2" should have been "test value 2".');
     }
 
     public function testBBCode_parse()
     {
         $text = Text::byXml('test');
         $test = $text->get('bbcodeTest');
-        $this->assertEquals('test the <b>name</b> plz!', $test, 'The value of the id "bbcodeTest" should of been "test the <b>name</b> plz!" not "'.$test.'".');
+        $this->assertEquals('test the <b>name</b> plz!', $test, 'The value of the id "bbcodeTest" should have been "test the <b>name</b> plz!" not "'.$test.'".');
     }
 
     public function testBBCode_parseComplexDate()
     {
         $text = Text::byXml('test');
         $test = $text->get('bbcodeTestDate');
-        $this->assertEquals('this is an 1969-12-31 date...', $test, 'The value of the id "bbcodeTestDate" should of been "this is an 1969-12-31 date..." not "'.$test.'".');
+        $this->assertEquals('this is an 1969-12-31 date...', $test, 'The value of the id "bbcodeTestDate" should have been "this is an 1969-12-31 date..." not "'.$test.'".');
     }
 
     public function testBBCode_parseComplexDiv()
     {
         $text = Text::byXml('test');
         $test = $text->get('bbcodeTestDiv');
-        $this->assertEquals('this is an <div class="bob">hullo</div> div...', $test, 'The value of the id "bbcodeTestDiv" should of been "this is an <div class="bob">hullo</div> div..." not "'.$test.'".');
+        $this->assertEquals('this is an <div class="bob">hullo</div> div...', $test, 'The value of the id "bbcodeTestDiv" should have been "this is an <div class="bob">hullo</div> div..." not "'.$test.'".');
     }
     /*
     public function testBBCode_parseComplexInception()
     {
         $text = Text::byXml('test');
         $test = $text->get('bbcodeTestInception');
-        $this->assertEquals('this is an <div class="bob">hm or<span class="inception">hullo</span>test</div> div...', $test, 'The value of the id "bbcodeTestInception" should of been "this is an <div class="bob">hm or<span class="inception">hullo</span>test</div> div..." not "'.$test.'".');
+        $this->assertEquals('this is an <div class="bob">hm or<span class="inception">hullo</span>test</div> div...', $test, 'The value of the id "bbcodeTestInception" should have been "this is an <div class="bob">hm or<span class="inception">hullo</span>test</div> div..." not "'.$test.'".');
     }
      */
 }

--- a/UnitTest/classes/UserTest.php
+++ b/UnitTest/classes/UserTest.php
@@ -37,7 +37,7 @@ class UserTest extends PHPUnit_Framework_TestCase {
         $newUser->save();
 
         $user = User::byUsername('test');
-        $this->assertInstanceOf('MPF\User', $user, 'A user with the username "test" should of been created.');
+        $this->assertInstanceOf('MPF\User', $user, 'A user with the username "test" should have been created.');
         $this->assertTrue(date('Y-m-d') == substr($user->getCreationDate(), 0, 10), 'The creation of the new user should be the one of today.');
         $this->assertTrue(User::STATUS_NOTAPPROVED == $user->getCurrentStatus()->getValue(), 'The status after a new user creation should be 50 (User::STATUS_NOTAPPROVED).');
         $this->assertTrue("test" == $user->getUsername(), 'The username of the new user should be "test".');
@@ -52,10 +52,10 @@ class UserTest extends PHPUnit_Framework_TestCase {
         $this->assertFalse($user->addGroup(User\Group::ADMIN()), 'Unless a user in the admin group is logged in the user group ADMIN cant be assigned to a user.');
 
         $userById = User::byId($user->getId());
-        $this->assertInstanceOf('MPF\User', $userById, 'A user with the username "test" should of been created.');
+        $this->assertInstanceOf('MPF\User', $userById, 'A user with the username "test" should have been created.');
 
         $userByUsername = User::byUsername('test');
-        $this->assertInstanceOf('MPF\User', $userByUsername, 'A user with the username "test" should of been created.');
+        $this->assertInstanceOf('MPF\User', $userByUsername, 'A user with the username "test" should have been created.');
 
     }
 }


### PR DESCRIPTION
Some unit tests have "should of" instead of the correct form "should have", this fixes those occurrences.
